### PR TITLE
Add ability to build network from rekordbox m3u survey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.json
 *.egg-info
 build/
+rekordbox_histories/

--- a/README.md
+++ b/README.md
@@ -22,10 +22,19 @@ bidirectional (mixing in both directions works well).
 
 ## Installation
 
-To install the Python package, run
+To install the Python package and CLI, run
 
 ``` sh
 pip install .
+```
+
+## Command Line Interface
+
+All functions of mix-memory are exposed via a command-line interface. See the various
+commands by running
+
+``` sh
+mix-memory --help
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ A track network can be loaded from Rekordbox history playlists.
 1. Export all relevant history playlists from Rekordbox in `.m3u8` format. Save or copy
 these to a directory in this project e.g. `./rekordbox_histories`.
 2. If there is no existing library or track network in the database, or if you wish to 
-overwrite an existing track network, run the following command. Optionally supply a 
-minimum date to read from in the format YYYY-MM-DD.
+overwrite an existing track network, run the `load-track-network-from-rekordbox-histories`
+command. Optionally supply a minimum date to read from in the format YYYY-MM-DD.
 
 ``` sh
 mix-memory load-track-network-from-rekordbox-histories --min-date {min_date}
@@ -55,11 +55,23 @@ mix-memory load-track-network-from-rekordbox-histories --min-date {min_date}
 option to save good transitions for future reference.
 
 3. If there is an existing library or track network in the database, and you wish to
-update this with new track transitions, run the following command. Use the minimum
-date argument to only transitions from new playlists into the track network.
+update this with new track transitions, run the `update-track-network-from-rekordbox-histories` 
+command. Use the minimum date argument to only transitions from new playlists into the
+track network.
 
 ``` sh
 mix-memory update-track-network-from-rekordbox-histories --min-date {min_date}
+```
+
+Both of these commands will prompt a survey with which you can save good transitions
+from each history playlist, like so:
+
+```
+=== Transitions Survey: HISTORY 2024-10-26.m3u8 ===
+Mark good transitions for each suggested pair.
+Type 'y' for Yes, 'n' for No, or 'Ctrl+C' to exit.
+
+Len Lewis - Morpheus -> Corporation & DJ Scattie - Heat & Fire? [y/N]: 
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Intro
 
-Mix Memory is a proof-of-concept feature suggestion for AlphaTheta's Rekordbox software, 
+`mix-memory` is a proof-of-concept feature suggestion for AlphaTheta's Rekordbox software, 
 developed in Python and visualized using d3.js.
 
 The idea is to provide DJs with a tool to store and recall successful track transitions, 
@@ -35,6 +35,31 @@ commands by running
 
 ``` sh
 mix-memory --help
+```
+
+### Loading from Rekordbox histories
+
+A track network can be loaded from Rekordbox history playlists.
+
+1. Export all relevant history playlists from Rekordbox in `.m3u8` format. Save or copy
+these to a directory in this project e.g. `./rekordbox_histories`.
+2. If there is no existing library or track network in the database, or if you wish to 
+overwrite an existing track network, run the following command. Optionally supply a 
+minimum date to read from in the format YYYY-MM-DD.
+
+``` sh
+mix-memory load-track-network-from-rekordbox-histories --min-date {min_date}
+```
+
+`mix-memory` will survey you on each transition in the history playlists, giving you the
+option to save good transitions for future reference.
+
+3. If there is an existing library or track network in the database, and you wish to
+update this with new track transitions, run the following command. Use the minimum
+date argument to only transitions from new playlists into the track network.
+
+``` sh
+mix-memory update-track-network-from-rekordbox-histories --min-date {min_date}
 ```
 
 ## Examples

--- a/mix_memory/cli.py
+++ b/mix_memory/cli.py
@@ -47,7 +47,7 @@ def cli(ctx: click.Context, db_name: str):
     "--force", is_flag=True, help="Force recreation without asking for confirmation."
 )
 @click.pass_context
-def initdb(ctx: click.Context, force: bool) -> None:
+def init_db(ctx: click.Context, force: bool) -> None:
     """Drop existing database and recreate with empty tables."""
     db_name = ctx.obj["db_name"]
 
@@ -107,10 +107,9 @@ def add_connection(
 @click.argument("track_artist")
 @click.argument("track_title")
 @click.pass_context
-def recommend_next_tracks(
-    ctx: click.Context, track_artist: str, track_title: str
-) -> None:
-    """Recommend the next tracks from a given track based on saved transitions."""
+def next_track_options(ctx: click.Context, track_artist: str, track_title: str) -> None:
+    """Recommend options for the next track from a given track based on saved
+    transitions."""
     db_name = ctx.obj["db_name"]
     track_network = load_track_network_from_db(db_name)
 
@@ -165,7 +164,7 @@ def export_network_for_d3(ctx: click.Context, output_file: str) -> None:
     help="The minimum date to read Rekordbox history playlists from. Optional.",
 )
 @click.pass_context
-def load_network_from_rekordbox_histories(
+def load_track_network_from_rekordbox_histories(
     ctx: click.Context, rekordbox_histories_dir: str, min_date: datetime.date
 ) -> None:
     db_name = ctx.obj["db_name"]

--- a/mix_memory/cli.py
+++ b/mix_memory/cli.py
@@ -164,7 +164,10 @@ def export_network_for_d3(ctx: click.Context, output_file: str) -> None:
 @click.option(
     "--min-date",
     type=click.DateTime(formats=["%Y-%m-%d"]),
-    help="The minimum date to read Rekordbox history playlists from. Optional.",
+    help=(
+        "The minimum date to read Rekordbox history playlists from. Format YYYY-MM-DD. "
+        "Optional."
+    ),
 )
 @click.pass_context
 def load_track_network_from_rekordbox_histories(
@@ -197,7 +200,10 @@ def load_track_network_from_rekordbox_histories(
 @click.option(
     "--min-date",
     type=click.DateTime(formats=["%Y-%m-%d"]),
-    help="The minimum date to read Rekordbox history playlists from. Optional.",
+    help=(
+        "The minimum date to read Rekordbox history playlists from. Format YYYY-MM-DD. "
+        "Optional."
+    ),
 )
 @click.pass_context
 def update_track_network_from_rekordbox_histories(

--- a/mix_memory/database.py
+++ b/mix_memory/database.py
@@ -57,13 +57,13 @@ class LibraryData(DBData):
     def from_library(cls, library: Library) -> "LibraryData":
         rows = [
             {"id": track_id, "artist": track.artist, "title": track.title}
-            for track_id, track in library.tracks.items()
+            for track_id, track in library.track_map.items()
         ]
         return cls(rows=rows)
 
     def to_library(self) -> Library:
         return Library(
-            tracks={
+            track_map={
                 row["id"]: Track(artist=row["artist"], title=row["title"])
                 for row in self.rows
             }

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -93,6 +93,12 @@ class Library:
     def __len__(self) -> int:
         return len(self.track_map)
 
+    def tracks(self) -> list[Track]:
+        return list(self.track_map.values())
+
+    def track_ids(self) -> list[int]:
+        return list(self.track_map.keys())
+
     def add_track(self, track: Track) -> None:
         """Add a track to the library.
 

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -146,4 +146,6 @@ class Library:
 
     def extend(self, other: "Library") -> "Library":
         """Merges one library with another library."""
-        return Library.track_map.update(other.track_map)
+        merged_track_map = self.track_map.copy()
+        merged_track_map.update(other.track_map)
+        return Library(track_map=merged_track_map)

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -1,3 +1,4 @@
+import hashlib
 from pathlib import Path
 
 
@@ -13,7 +14,8 @@ class Track:
         self.title = title
 
         # A simple 8-digit hash to use as a track ID
-        self.hash8 = abs(hash(self)) % (10**8)
+        hash_input = str(self.__key).encode("utf-8")
+        self.hash8 = int(hashlib.md5(hash_input).hexdigest()[:8], 16)
 
     def __repr__(self) -> str:
         return f"Track(artist={self.artist}, title={self.title})"
@@ -31,7 +33,7 @@ class Track:
         raise NotImplementedError
 
     def __hash__(self) -> int:
-        return hash(self.__key)
+        return self.hash8
 
 
 class MissingTrackError(Exception):

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -72,7 +72,7 @@ class Library:
 
         with file_path.open("r") as f:
             lines = f.readlines()
-            extinf_lines = [l for l in lines if l.startswith("#EXTINF")]
+            extinf_lines = [l.strip() for l in lines if l.startswith("#EXTINF")]
             for line in extinf_lines:
                 title_artist = line.split(",", 1)[1]
                 title, artist = title_artist.split(" - ", 1)
@@ -165,6 +165,7 @@ class Library:
 
 def merge_libraries(libraries: list[Library]) -> Library:
     """Merge many libraries into one."""
+    libraries = libraries.copy()
     library = libraries.pop()
 
     for other in libraries:

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -46,6 +46,9 @@ class Library:
         Args:
             track_hashmap: a dictionary with track IDs mapped to Track objects.
         """
+        if track_map is None:
+            track_map = {}
+
         self.track_map = track_map
 
     @classmethod

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -52,7 +52,8 @@ class Library:
         """Initialize the Library object.
 
         Args:
-            track_hashmap: a dictionary with track IDs mapped to Track objects.
+            track_map: a dictionary with track IDs mapped to Track objects. If None,
+                the library will be empty.
         """
         if track_map is None:
             track_map = {}

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -25,7 +25,7 @@ class Track:
     def hash(self) -> int:
         """Hash the track, on the basis that a track is described by a unique key of
         {artist,title}."""
-        return hash(self.artist + self.title)
+        return abs(hash(self.artist + self.title)) % (10**8)
 
 
 class MissingTrackError(Exception):
@@ -65,8 +65,8 @@ class Library:
             lines = f.readlines()
             extinf_lines = [l for l in lines if l.startswith("#EXTINF")]
             for line in extinf_lines:
-                title_artist = line.split(",")[1]
-                title, artist = title_artist.split(" - ")
+                title_artist = line.split(",", 1)[1]
+                title, artist = title_artist.split(" - ", 1)
                 track_list.append(Track(title, artist))
 
         return cls.from_track_list(track_list=track_list)

--- a/mix_memory/library.py
+++ b/mix_memory/library.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import hashlib
 
 
 __all__ = ["Track", "Library"]
@@ -162,3 +161,13 @@ class Library:
         merged_track_map = self.track_map.copy()
         merged_track_map.update(other.track_map)
         return Library(track_map=merged_track_map)
+
+
+def merge_libraries(libraries: list[Library]) -> Library:
+    """Merge many libraries into one."""
+    library = libraries.pop()
+
+    for other in libraries:
+        library = library.extend(other)
+
+    return library

--- a/mix_memory/rekordbox.py
+++ b/mix_memory/rekordbox.py
@@ -38,18 +38,24 @@ class RekordboxHistoryM3UFile:
         self.date_file_number = match.group(3) if match.group(3) else 1
 
 
+# TODO: update repr and str
 class RekordboxHistoryPlaylist(Library):
     """A library specifically representing the tracks in a Rekordbox history
     playlist. Because a Rekordbox history playlist is ordered by the track play time,
     it serves as a good record of all the transitions a DJ made during a certain set."""
 
     def __init__(
-        self, track_map: dict[int, Track], date: datetime.date, date_file_number: int
+        self,
+        track_map: dict[int, Track],
+        name: str,
+        date: datetime.date,
+        date_file_number: int,
     ) -> None:
         """Initialize the RekordboxHistoryPlaylist from a track map and metadata. For a
         RekordboxHistoryPlaylist, the track map must be ordered sequentially according
         to when the track was played."""
         super().__init__(track_map=track_map)
+        self.name = name
         self.date = date
         self.date_file_number = date_file_number
 
@@ -67,6 +73,7 @@ class RekordboxHistoryPlaylist(Library):
 
         return cls(
             track_map=library.track_map,
+            name=file.name,
             date=file.date,
             date_file_number=file.date_file_number,
         )

--- a/mix_memory/rekordbox.py
+++ b/mix_memory/rekordbox.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+from pathlib import Path
+import re
+from mix_memory.library import Library, Track, merge_libraries
+
+
+class RekordboxHistoryM3UFile:
+    """The exported .m3u8 file of a Rekordbox history playlist. Used for validating the
+    filename and extracting the date and date file number of the file.
+
+    Examples:
+        - "HISTORY 2023-07-28.m3u8"
+        - "HISTORY 2023-07-28 (4).m3u8"
+    """
+
+    filename_pattern = re.compile(r"^HISTORY (\d{4}-\d{2}-\d{2}) ?(\((\d+)\))?\.m3u8$")
+
+    def __init__(self, file_path: Path) -> None:
+        """Initialize the RekordboxHistoryM3UFile from the file path.
+
+        Raises:
+            ValueError: if the file name doesn't match the usual syntax of a Rekordbox
+                history playlist file.
+        """
+        file_name = file_path.name
+        match = self.filename_pattern.match(file_name)
+        if not match:
+            raise ValueError(
+                f"File name doesn't match Rekordbox history pattern: {file_name}"
+            )
+
+        self.path = file_path
+        self.name = file_name
+
+        # Extract variables from regex groups
+        date_str = match.group(1)
+        self.date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        self.date_file_number = match.group(3) if match.group(3) else 1
+
+
+class RekordboxHistoryPlaylist(Library):
+    """A library specifically representing the tracks in a Rekordbox history
+    playlist. Because a Rekordbox history playlist is ordered by the track play time,
+    it serves as a good record of all the transitions a DJ made during a certain set."""
+
+    def __init__(
+        self, track_map: dict[int, Track], date: datetime.date, date_file_number: int
+    ) -> None:
+        """Initialize the RekordboxHistoryPlaylist from a track map and metadata. For a
+        RekordboxHistoryPlaylist, the track map must be ordered sequentially according
+        to when the track was played."""
+        super().__init__(track_map=track_map)
+        self.date = date
+        self.date_file_number = date_file_number
+
+    @classmethod
+    def from_m3u_file(cls, file_path: str | Path) -> "RekordboxHistoryPlaylist":
+        """Initialize the RekordboxHistoryPlaylist from the tracks and metadata in its
+        .m3u8 file."""
+        if isinstance(file_path, str):
+            file_path = Path(file_path)
+
+        library = Library.from_m3u_file(file_path=file_path)
+
+        # Load other metadata from the file e.g. the date
+        file = RekordboxHistoryM3UFile(file_path=file_path)
+
+        return cls(
+            track_map=library.track_map,
+            date=file.date,
+            date_file_number=file.date_file_number,
+        )
+
+    def transitions(self) -> list[tuple[Track]]:
+        """Because a Rekordbox history playlist is ordered by the track play time, it
+        can be used as a record of all the transitions a DJ made during a set."""
+        tracks = self.tracks()
+
+        # Construct the list of transitions by pairing each track to the next
+        transitions = [(tracks[i], tracks[i + 1]) for i, _ in enumerate(tracks[:-1])]
+        return transitions
+
+
+def load_rekordbox_histories_since(
+    rekordbox_histories_dir: str | Path, min_date: datetime.date
+) -> list[RekordboxHistoryPlaylist]:
+    """Load multiple history playlists since a given date.
+
+    Arguments:
+        rekordbox_histories_dir: A directory containing exported .m3u8 files from
+            Rekordbox history playlists.
+        min_date: The minimum date from which history files should be read.
+    """
+    # Force path if str is given
+    rekordbox_histories_dir = Path(rekordbox_histories_dir)
+
+    rekordbox_history_files = [
+        RekordboxHistoryM3UFile(f) for f in rekordbox_histories_dir.glob("*.m3u8")
+    ]
+
+    files_after_min_date = [f for f in rekordbox_history_files if f.date >= min_date]
+
+    playlists = [
+        RekordboxHistoryPlaylist.from_m3u_file(f.path) for f in files_after_min_date
+    ]
+
+    return playlists

--- a/mix_memory/rekordbox.py
+++ b/mix_memory/rekordbox.py
@@ -35,7 +35,7 @@ class RekordboxHistoryM3UFile:
         # Extract variables from regex groups
         date_str = match.group(1)
         self.date = datetime.strptime(date_str, "%Y-%m-%d").date()
-        self.date_file_number = match.group(3) if match.group(3) else 1
+        self.date_file_number = match.group(3) if match.group(3) else 0
 
 
 # TODO: update repr and str
@@ -119,6 +119,11 @@ def load_rekordbox_histories_since(
         raise ValueError(
             "No files were found to match the criteria. Consider a longer date range."
         )
+
+    # Sort files by date and file number
+    rekordbox_history_files = sorted(
+        rekordbox_history_files, key=lambda f: str(f.date) + str(f.date_file_number)
+    )
 
     playlists = [
         RekordboxHistoryPlaylist.from_m3u_file(f.path) for f in rekordbox_history_files

--- a/mix_memory/rekordbox.py
+++ b/mix_memory/rekordbox.py
@@ -1,7 +1,10 @@
 from datetime import datetime, date
 from pathlib import Path
 import re
-from mix_memory.library import Library, Track, merge_libraries
+from mix_memory.library import Library, Track
+
+
+__all__ = ["RekordboxHistoryPlaylist", "load_rekordbox_histories_since"]
 
 
 class RekordboxHistoryM3UFile:

--- a/mix_memory/rekordbox.py
+++ b/mix_memory/rekordbox.py
@@ -38,7 +38,18 @@ class RekordboxHistoryM3UFile:
         # Extract variables from regex groups
         date_str = match.group(1)
         self.date = datetime.strptime(date_str, "%Y-%m-%d").date()
-        self.date_file_number = match.group(3) if match.group(3) else 0
+        self.date_file_number = int(match.group(3) or 0)
+
+    def __repr__(self) -> str:
+        return (
+            f"RekordboxHistoryM3UFile("
+            f"path={self.path!r}, "
+            f"date={self.date}, "
+            f"date_file_number={self.date_file_number})"
+        )
+
+    def __str__(self) -> str:
+        return f"{self.name} (Date: {self.date}, File #: {self.date_file_number})"
 
 
 # TODO: update repr and str
@@ -82,13 +93,20 @@ class RekordboxHistoryPlaylist(Library):
         )
 
     def transitions(self) -> list[tuple[Track]]:
-        """Because a Rekordbox history playlist is ordered by the track play time, it
-        can be used as a record of all the transitions a DJ made during a set."""
+        """Returns a list of track-to-track transitions from the history playlist."""
         tracks = self.tracks()
 
         # Construct the list of transitions by pairing each track to the next
         transitions = [(tracks[i], tracks[i + 1]) for i, _ in enumerate(tracks[:-1])]
         return transitions
+
+    def __repr__(self) -> str:
+        return f"RekordboxHistoryPlaylist(name={self.name!r}, date={self.date}, tracks={len(self.track_map)})"
+
+    def __str__(self) -> str:
+        return (
+            f"Playlist: {self.name} | Date: {self.date} | Tracks: {len(self.track_map)}"
+        )
 
 
 def load_rekordbox_histories_since(
@@ -124,9 +142,7 @@ def load_rekordbox_histories_since(
         )
 
     # Sort files by date and file number
-    rekordbox_history_files = sorted(
-        rekordbox_history_files, key=lambda f: str(f.date) + str(f.date_file_number)
-    )
+    rekordbox_history_files.sort(key=lambda f: (f.date, f.date_file_number))
 
     playlists = [
         RekordboxHistoryPlaylist.from_m3u_file(f.path) for f in rekordbox_history_files

--- a/mix_memory/track_network.py
+++ b/mix_memory/track_network.py
@@ -65,7 +65,7 @@ class TrackNetwork:
         graph = nx.DiGraph()
 
         # Add nodes to the graph
-        for track_id in library.tracks.keys():
+        for track_id in library.track_map.keys():
             graph.add_node(track_id)
 
         # Add edges to graph


### PR DESCRIPTION
- Update library.py to hash tracks with a deterministic hash based on artist and title (avoids track duplication in library)
- Add rekordbox.py to load history playlists from a directory of .m3u8 exports
- Update cli.py to add new commands, enabling user to build track network from Rekordbox history playlist .m3u8 exports
- Update README to walk through new method of building track network